### PR TITLE
Default to relative path instead of localhost for domain.

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -143,10 +143,11 @@ export class Generator {
 
   private static generateDomain({schemes, host, basePath}: Swagger): string {
 
-    const protocol =
-        host && schemes && schemes.length > 0
-        ? `${schemes[0]}://`
-        : '//';
+    // if the host is defined then try and use a protocol from the swagger file. Otherwise just send
+    // requests using the same protocol as the library was loaded with.
+    const protocol = host && schemes && schemes.length > 0 ? `${schemes[0]}://` : '//';
+
+    // if no host exists in the swagger file default to effectively a relative path.
     const domain = host ? host : "${window.location.hostname}${window.location.port ? ':'+window.location.port : ''}";
     const base = ('/' === basePath || !basePath ? '' : basePath);
     return `${protocol}${domain}${base}`;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -142,12 +142,13 @@ export class Generator {
   };
 
   private static generateDomain({schemes, host, basePath}: Swagger): string {
+
     const protocol =
-      schemes && schemes.length > 0
+        host && schemes && schemes.length > 0
         ? `${schemes[0]}://`
         : '//';
     const domain = host ? host : "${window.location.hostname}${window.location.port ? ':'+window.location.port : ''}";
-    const base = ('/' === basePath ? '' : basePath);
+    const base = ('/' === basePath || !basePath ? '' : basePath);
     return `${protocol}${domain}${base}`;
   }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -144,11 +144,11 @@ export class Generator {
   private static generateDomain({schemes, host, basePath}: Swagger): string {
     const protocol =
       schemes && schemes.length > 0
-        ? schemes[0]
-        : 'http';
-    const domain = host ? host : 'localhost';
+        ? `${schemes[0]}://`
+        : '//';
+    const domain = host ? host : "${window.location.hostname}${window.location.port ? ':'+window.location.port : ''}";
     const base = ('/' === basePath ? '' : basePath);
-    return `${protocol}://${domain}${base}`;
+    return `${protocol}${domain}${base}`;
   }
 
   private static generateDefinitions(definitions: { [definitionsName: string]: Schema } = {}): Definition[] {

--- a/templates/ngx-service.mustache
+++ b/templates/ngx-service.mustache
@@ -17,6 +17,8 @@ interface HttpOptions {
   withCredentials?: boolean,
 }
 
+declare var window;
+
 /**
  * Created with ngx-swagger-client-generator (https://github.com/flowup/ngx-swagger-client-generator)
  */
@@ -24,13 +26,16 @@ interface HttpOptions {
 export class ApiClientService {
 
   readonly options: HttpOptions;
-  private domain = 'http://localhost:8080';
+  private domain: string;
 
   constructor(private http: HttpClient,
               @Optional() @Inject('domain') domain: string,
               @Optional() @Inject('httpOptions') options: HttpOptions) {
-    if (domain) {
-      this.domain = domain;
+
+    this.domain = domain;
+    if (!this.domain) {
+      // if no domain is specified emulate a relative path.
+      this.domain = "//"+window.location.hostname + (window.location.port ? ":"+window.location.port : "") + "/";
     }
 
     this.options = {

--- a/templates/ngx-service.mustache
+++ b/templates/ngx-service.mustache
@@ -24,14 +24,15 @@ interface HttpOptions {
 export class ApiClientService {
 
   readonly options: HttpOptions;
-  private domain: string;
+  private domain: string = `{{&domain}}`;
 
   constructor(private http: HttpClient,
               @Optional() @Inject('domain') domain: string,
               @Optional() @Inject('httpOptions') options: HttpOptions) {
 
-    // if no domain is specified emulate a relative path.
-    this.domain = domain || `//${window.location.hostname}${window.location.port ? ":"+window.location.port : ""}/`;
+    if (domain) {
+        this.domain = domain;
+    }
 
     this.options = {
       headers: options && options.headers ? options.headers : new HttpHeaders(),

--- a/templates/ngx-service.mustache
+++ b/templates/ngx-service.mustache
@@ -31,7 +31,7 @@ export class ApiClientService {
               @Optional() @Inject('httpOptions') options: HttpOptions) {
 
     if (domain) {
-        this.domain = domain;
+      this.domain = domain;
     }
 
     this.options = {

--- a/templates/ngx-service.mustache
+++ b/templates/ngx-service.mustache
@@ -17,8 +17,6 @@ interface HttpOptions {
   withCredentials?: boolean,
 }
 
-declare var window;
-
 /**
  * Created with ngx-swagger-client-generator (https://github.com/flowup/ngx-swagger-client-generator)
  */
@@ -32,11 +30,8 @@ export class ApiClientService {
               @Optional() @Inject('domain') domain: string,
               @Optional() @Inject('httpOptions') options: HttpOptions) {
 
-    this.domain = domain;
-    if (!this.domain) {
-      // if no domain is specified emulate a relative path.
-      this.domain = "//"+window.location.hostname + (window.location.port ? ":"+window.location.port : "") + "/";
-    }
+    // if no domain is specified emulate a relative path.
+    this.domain = domain || `//${window.location.hostname}${window.location.port ? ":"+window.location.port : ""}/`;
 
     this.options = {
       headers: options && options.headers ? options.headers : new HttpHeaders(),


### PR DESCRIPTION
Changes the template to use the window location as the default domain. This seems like a more sensible default. In general it seems to be rather awkward to inject the domain when switching between different API environments (e.g. staging vs prod deployment).

I've not regenerated the code or anything but I assume I didn't break anything.

